### PR TITLE
Set default concurrency if options are not passed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ var restrict = function(info, by) {
 var Readable = function(sourceConfig, source, options) {
   stream.Readable.call(this, {
     objectMode: true,
-    highWaterMark: options.concurrency
+    highWaterMark: options && options.concurrency ? options.concurrency : DEFAULT_CONCURRENCY
   });
 
   // set some defaults
@@ -133,6 +133,7 @@ var Readable = function(sourceConfig, source, options) {
   });
 
   var pending = 0;
+  var CONCURRENCY = options && options.concurrency ? options.concurrency : DEFAULT_CONCURRENCY;
 
   this._read = function() {
     // limit the number of concurrent reads pending
@@ -214,7 +215,7 @@ util.inherits(Readable, stream.Readable);
 var Collector = function(options) {
   stream.Transform.call(this, {
     objectMode: true,
-    highWaterMark: options.concurrency
+    highWaterMark: options && options.concurrency ? options.concurrency : DEFAULT_CONCURRENCY
   });
 
   this.on("pipe", function(src) {
@@ -281,7 +282,7 @@ util.inherits(Collector, stream.Transform);
 var Writable = function(sink, options) {
   stream.Writable.call(this, {
     objectMode: true,
-    highWaterMark: options.concurrency
+    highWaterMark: options && options.concurrency ? options.concurrency : DEFAULT_CONCURRENCY
   });
 
   this._write = function(obj, _, callback) {


### PR DESCRIPTION
The addition of concurrency options breaks many modules that already rely on
using tilelive-streaming without passing concurrency settings. This can be
avoided by using the default concurrency settings if no options are passed in.
Further, an undeclared ```CONCURRENCY``` variable would cause the program to crash.
This can also be avoided by declaring this value and setting it to the default
if no options are given.

Fixes https://github.com/mojodna/tilelive-streaming/issues/3