### PR TITLE
Fix TypeError('listener must be a function');

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,7 +338,7 @@ var streamTile = function(source, getTile, passThrough, z, x, y, context, callba
   getTile(z, x, y, function(err, data, headers) {
     if (err) {
       setImmediate(function() {
-        tileStream.on("error", err);
+        tileStream.on("error", function(err){return err});
       });
     }
 


### PR DESCRIPTION
This patch fixed the following error for me.  

```
events.js:130
    throw TypeError('listener must be a function');
    ^
TypeError: listener must be a function
    at TypeError (<anonymous>)
    at EventEmitter.addListener (events.js:130:11)
    at Readable.on (_stream_readable.js:689:33)
    at Object._onImmediate (/usr/local/lib/node_modules/tessera/node_modules/tilelive-cache/node_modules/tilelive-streaming/index.js:341:20)
    at processImmediate [as _immediateCallback] (timers.js:330:15)
Listening at http://0.0.0.0:8080/
```