### PR TITLE
Export methods for use by `lib/mbtiles` as a source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## v0.6.1 - 2/15/16
+
+* Export `applyDefaults` and `clone` for use by `lib/mbtiles` as a source (james.flemer@ndpgroup.com)
+
 ## v0.6.0 - 1/7/16
 
 * Fix off-by-one in concurrency handling

--- a/index.js
+++ b/index.js
@@ -544,4 +544,6 @@ module.exports.Collector = Collector;
 module.exports.Readable = Readable;
 module.exports.TileStream = TileStream;
 module.exports.Writable = Writable;
+module.exports.applyDefaults = applyDefaults;
+module.exports.clone = clone;
 module.exports.restrict = restrict;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-streaming",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Streaming functionality for tilelive modules",
   "main": "index.js",
   "author": "Seth Fitzsimmons <seth@mojodna.net>",


### PR DESCRIPTION
This enables using a `mbtiles://` source for `tl copy`
